### PR TITLE
fix: update migrations for nullable foreign key and constraints

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,8 +13,12 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id('user_id');
-            $table->foreignIdFor(Achievement::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id')->primary();
+            // $table->foreignIdFor(Achievement::class)->constrained()->cascadeOnDelete();
+            // $table->foreignIdFor(Achievement::class)->constrained()->cascadeOnDelete();
+            $table->string('achievement_id')->nullable();
+            $table->foreign('achievement_id')->references('achievement_id')->on('achievements')->onDelete('cascade');
+            // $table->foreignId('achievement_id')->references('achievement_id')->on('achievements')->onDelete('cascade');
             $table->string('username');
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/2024_08_17_050153_create_kokos_table.php
+++ b/database/migrations/2024_08_17_050153_create_kokos_table.php
@@ -23,8 +23,10 @@ return new class extends Migration
 
         Schema::create('user_koko', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Koko::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
+            $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade'); 
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_08_17_050220_create_attendances_table.php
+++ b/database/migrations/2024_08_17_050220_create_attendances_table.php
@@ -15,8 +15,9 @@ return new class extends Migration
     {
         Schema::create('attendances', function (Blueprint $table) {
             $table->id('attendance_id');
-            $table->foreignId('user_id')->constrained('users', 'user_id')->onDelete('cascade');
-            $table->string('koko_id'); // Changed to string to match koko_id type
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
             $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade');            
             $table->boolean('status');
             $table->timestamps();

--- a/database/migrations/2024_08_17_050229_create_posts_table.php
+++ b/database/migrations/2024_08_17_050229_create_posts_table.php
@@ -15,8 +15,10 @@ return new class extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->id('post_id');
-            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Koko::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
+            $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade'); 
             $table->string('tag');
             $table->string('title');
             $table->string('content');

--- a/database/migrations/2024_08_17_050239_create_achievements_table.php
+++ b/database/migrations/2024_08_17_050239_create_achievements_table.php
@@ -15,8 +15,10 @@ return new class extends Migration
     {
         Schema::create('achievements', function (Blueprint $table) {
             $table->id('achievement_id');
-            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Koko::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
+            $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade'); 
             $table->string('name');
             $table->string('years');
             $table->string('tier');

--- a/database/migrations/2024_08_17_050248_create_broadcasts_table.php
+++ b/database/migrations/2024_08_17_050248_create_broadcasts_table.php
@@ -15,8 +15,10 @@ return new class extends Migration
     {
         Schema::create('broadcasts', function (Blueprint $table) {
             $table->string('broadcast_id')->primary();
-            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Koko::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
+            $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade'); 
             $table->string('title');
             $table->string('type');
             $table->string('content');


### PR DESCRIPTION
- Alter `users` table to use nullable `achievement_id` with proper foreign key constraints.
- Adjust migration files to ensure accurate foreign key relationships and cascading behavior.