### PR TITLE
fix: update UserSeeder to correctly associate achievements

### DIFF
--- a/app/Models/Achievement.php
+++ b/app/Models/Achievement.php
@@ -9,4 +9,8 @@ class Achievement extends Model
 {
     protected $table = 'achievements';
     use HasFactory;
+    protected $primaryKey = 'achievement_id';
+    public $incrementing = false;
+    protected $keyType = 'string';
+    protected $fillable = ['achievement_id', 'name', 'year', 'tier', 'user_id'];
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -18,11 +18,10 @@ class User extends Authenticatable
      *
      * @var array<int, string>
      */
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-    ];
+    protected $primaryKey = 'user_id';
+    public $incrementing = false;
+    protected $keyType = 'string';
+    protected $fillable = ['user_id', 'achievement_id', 'username', 'password', 'remember_token'];
 
     /**
      * The attributes that should be hidden for serialization.

--- a/database/factories/AchievementFactory.php
+++ b/database/factories/AchievementFactory.php
@@ -17,8 +17,10 @@ class AchievementFactory extends Factory
     {
         $tier = ['School', 'District', 'State', 'National'];
         return [
-            'user_id' => User::factory(),
-            'koko_id' => Koko::factory(),
+            'user_id' => User::inRandomOrder()->first()->user_id,
+            // 'koko_id' => Koko::factory(),
+            // 'user_id' => null,
+            'koko_id' => Koko::inRandomOrder()->first()->koko_id,
             'name' => 'Sample Achievement Name',
             'years' => $this->faker->year(),
             'tier' => $this->faker->randomElement($tier),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,35 +4,18 @@ namespace Database\Factories;
 
 use App\Models\User;
 use App\Models\Achievement;
-use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 class UserFactory extends Factory
 {
-    /**
-     * The name of the factory's corresponding model.
-     *
-     * @var string
-     */
     protected $model = User::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array
-     */
     public function definition(): array
     {
-        // Define prefixes and user types
-        $prefixes = [
-            'student' => 'S',
-            'teacher' => 'T',
-        ];
-
-        // Randomly select a user type
-        $userType = array_rand($prefixes);
-        $prefix = $prefixes[$userType];
+        $prefixes = ['S', 'T'];
+        $prefix = $this->faker->randomElement($prefixes);
 
         // Generate a unique ID with prefix
         static $counter = 1;
@@ -40,7 +23,7 @@ class UserFactory extends Factory
 
         return [
             'user_id' => $userId,
-            'achievement_id' => Achievement::factory(),
+            'achievement_id' => null, // Set this to null initially
             'username' => $this->faker->unique()->userName,
             'password' => Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -3,17 +3,18 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\Achievement;
 use Illuminate\Database\Seeder;
 
 class UserSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
-        // Seed 50 users
-        User::factory()->count(50)->create();    
+        $users = User::factory()->count(50)->create();
+
+        $users->each(function ($user) {
+            $achievement = Achievement::factory()->create(['user_id' => $user->user_id]);
+            $user->update(['achievement_id' => $achievement->id]);
+        });
     }
 }


### PR DESCRIPTION
- Modify `UserSeeder` to ensure that `achievement_id` is updated for each user after creation.

fix: update AchievementFactory to use existing records for relationships
- Adjust `AchievementFactory` to reference existing `User` and `Koko` records rather than creating new ones.