### PR TITLE
fix: update migrations for nullable foreign key and constraints

### DIFF
--- a/database/factories/AchievementFactory.php
+++ b/database/factories/AchievementFactory.php
@@ -17,8 +17,10 @@ class AchievementFactory extends Factory
     {
         $tier = ['School', 'District', 'State', 'National'];
         return [
-            'user_id' => User::factory(),
-            'koko_id' => Koko::factory(),
+            'user_id' => User::inRandomOrder()->first()->user_id,
+            // 'koko_id' => Koko::factory(),
+            // 'user_id' => null,
+            'koko_id' => Koko::inRandomOrder()->first()->koko_id,
             'name' => 'Sample Achievement Name',
             'years' => $this->faker->year(),
             'tier' => $this->faker->randomElement($tier),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,35 +4,18 @@ namespace Database\Factories;
 
 use App\Models\User;
 use App\Models\Achievement;
-use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 class UserFactory extends Factory
 {
-    /**
-     * The name of the factory's corresponding model.
-     *
-     * @var string
-     */
     protected $model = User::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array
-     */
     public function definition(): array
     {
-        // Define prefixes and user types
-        $prefixes = [
-            'student' => 'S',
-            'teacher' => 'T',
-        ];
-
-        // Randomly select a user type
-        $userType = array_rand($prefixes);
-        $prefix = $prefixes[$userType];
+        $prefixes = ['S', 'T'];
+        $prefix = $this->faker->randomElement($prefixes);
 
         // Generate a unique ID with prefix
         static $counter = 1;
@@ -40,7 +23,7 @@ class UserFactory extends Factory
 
         return [
             'user_id' => $userId,
-            'achievement_id' => Achievement::factory(),
+            'achievement_id' => null, // Set this to null initially
             'username' => $this->faker->unique()->userName,
             'password' => Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,8 +13,12 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id('user_id');
-            $table->foreignIdFor(Achievement::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id')->primary();
+            // $table->foreignIdFor(Achievement::class)->constrained()->cascadeOnDelete();
+            // $table->foreignIdFor(Achievement::class)->constrained()->cascadeOnDelete();
+            $table->string('achievement_id')->nullable();
+            $table->foreign('achievement_id')->references('achievement_id')->on('achievements')->onDelete('cascade');
+            // $table->foreignId('achievement_id')->references('achievement_id')->on('achievements')->onDelete('cascade');
             $table->string('username');
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -14,11 +14,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->string('user_id')->primary();
-            // $table->foreignIdFor(Achievement::class)->constrained()->cascadeOnDelete();
-            // $table->foreignIdFor(Achievement::class)->constrained()->cascadeOnDelete();
-            $table->string('achievement_id')->nullable();
-            $table->foreign('achievement_id')->references('achievement_id')->on('achievements')->onDelete('cascade');
-            // $table->foreignId('achievement_id')->references('achievement_id')->on('achievements')->onDelete('cascade');
+            $table->unsignedBigInteger('achievement_id')->nullable();
             $table->string('username');
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/2024_08_17_050153_create_kokos_table.php
+++ b/database/migrations/2024_08_17_050153_create_kokos_table.php
@@ -23,8 +23,10 @@ return new class extends Migration
 
         Schema::create('user_koko', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Koko::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
+            $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade'); 
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_08_17_050220_create_attendances_table.php
+++ b/database/migrations/2024_08_17_050220_create_attendances_table.php
@@ -15,8 +15,9 @@ return new class extends Migration
     {
         Schema::create('attendances', function (Blueprint $table) {
             $table->id('attendance_id');
-            $table->foreignId('user_id')->constrained('users', 'user_id')->onDelete('cascade');
-            $table->string('koko_id'); // Changed to string to match koko_id type
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
             $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade');            
             $table->boolean('status');
             $table->timestamps();

--- a/database/migrations/2024_08_17_050229_create_posts_table.php
+++ b/database/migrations/2024_08_17_050229_create_posts_table.php
@@ -15,8 +15,10 @@ return new class extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->id('post_id');
-            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Koko::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
+            $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade'); 
             $table->string('tag');
             $table->string('title');
             $table->string('content');

--- a/database/migrations/2024_08_17_050239_create_achievements_table.php
+++ b/database/migrations/2024_08_17_050239_create_achievements_table.php
@@ -15,8 +15,10 @@ return new class extends Migration
     {
         Schema::create('achievements', function (Blueprint $table) {
             $table->id('achievement_id');
-            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Koko::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
+            $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade'); 
             $table->string('name');
             $table->string('years');
             $table->string('tier');

--- a/database/migrations/2024_08_17_050248_create_broadcasts_table.php
+++ b/database/migrations/2024_08_17_050248_create_broadcasts_table.php
@@ -15,8 +15,10 @@ return new class extends Migration
     {
         Schema::create('broadcasts', function (Blueprint $table) {
             $table->string('broadcast_id')->primary();
-            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Koko::class)->constrained()->cascadeOnDelete();
+            $table->string('user_id');
+            $table->foreign('user_id')->references('user_id')->on('users')->onDelete('cascade');
+            $table->string('koko_id');
+            $table->foreign('koko_id')->references('koko_id')->on('kokos')->onDelete('cascade'); 
             $table->string('title');
             $table->string('type');
             $table->string('content');

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -3,17 +3,18 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\Achievement;
 use Illuminate\Database\Seeder;
 
 class UserSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
-        // Seed 50 users
-        User::factory()->count(50)->create();    
+        $users = User::factory()->count(50)->create();
+
+        $users->each(function ($user) {
+            $achievement = Achievement::factory()->create(['user_id' => $user->user_id]);
+            $user->update(['achievement_id' => $achievement->id]);
+        });
     }
 }


### PR DESCRIPTION
- Alter `users` table to use nullable `achievement_id` with proper foreign key constraints.
- Adjust migration files to ensure accurate foreign key relationships and cascading behavior.